### PR TITLE
Feature/paper receipt payments

### DIFF
--- a/app/controller/app_controller.py
+++ b/app/controller/app_controller.py
@@ -633,8 +633,6 @@ class AppController:
         if method not in {self.RECEIPT_METHOD_ELECTRONIC, self.RECEIPT_METHOD_PAPER}:
             raise ValueError("收據型態必須為電子收據或紙本收據")
         paper_no = str((data or {}).get("paper_receipt_number") or "").strip()
-        if method == self.RECEIPT_METHOD_PAPER and not paper_no:
-            raise ValueError("紙本收據必須填寫紙本收據號")
         return method, paper_no if method == self.RECEIPT_METHOD_PAPER else ""
 
     @classmethod

--- a/app/controller/app_controller.py
+++ b/app/controller/app_controller.py
@@ -41,6 +41,8 @@ class AppController:
     LIGHTING_REFUND_EXPENSE_ITEM_ID = "91R"
     PAYMENT_METHOD_CASH = "cash"
     PAYMENT_METHOD_TRANSFER = "transfer"
+    RECEIPT_METHOD_ELECTRONIC = "ELECTRONIC"
+    RECEIPT_METHOD_PAPER = "PAPER"
     SYSTEM_LIGHTING_ITEMS = (
         ("L01", "太歲燈", 500, "TAI_SUI", 1),
         ("L02", "光明燈", 500, "BRIGHT", 2),
@@ -62,6 +64,7 @@ class AppController:
         self._ensure_lighting_schema()
         self._ensure_lighting_signup_schema()
         self._ensure_transactions_payment_schema()
+        self._ensure_business_receipt_schema()
         self._ensure_system_income_items()
         self._ensure_system_expense_items()
         self._ensure_runtime_indexes()
@@ -343,6 +346,8 @@ class AppController:
             f"收據 {self._fmt_log_val(d.get('receipt_number'))}",
             f"付款方式 {self._fmt_log_val(self._payment_method_label(d.get('payment_method')))}",
             f"轉帳末5碼 {self._fmt_log_val(d.get('transfer_last5'))}",
+            f"收據型態 {self._fmt_log_val(self._receipt_method_label(d.get('receipt_method')))}",
+            f"紙本收據 {self._fmt_log_val(d.get('paper_receipt_number'))}",
             f"備註 {self._fmt_log_val(d.get('note'))}",
             f"來源類型 {self._fmt_log_val(d.get('source_type'))}",
             f"來源ID {self._fmt_log_val(d.get('source_id'))}",
@@ -363,6 +368,8 @@ class AppController:
             ("receipt_number", "收據"),
             ("payment_method", "付款方式"),
             ("transfer_last5", "轉帳末5碼"),
+            ("receipt_method", "收據型態"),
+            ("paper_receipt_number", "紙本收據"),
             ("note", "備註"),
             ("source_type", "來源類型"),
             ("source_id", "來源ID"),
@@ -568,6 +575,22 @@ class AppController:
         if changed:
             self.conn.commit()
 
+    def _ensure_business_receipt_schema(self) -> None:
+        cur = self.conn.cursor()
+        changed = False
+        for table in ("transactions", "activity_signups", "lighting_signups"):
+            if not self._table_exists(table):
+                continue
+            cols = self._table_columns(table)
+            if "receipt_method" not in cols:
+                cur.execute(f"ALTER TABLE {table} ADD COLUMN receipt_method TEXT DEFAULT 'ELECTRONIC'")
+                changed = True
+            if "paper_receipt_number" not in cols:
+                cur.execute(f"ALTER TABLE {table} ADD COLUMN paper_receipt_number TEXT")
+                changed = True
+        if changed:
+            self.conn.commit()
+
     def _normalize_payment_fields(self, data: Dict[str, Any], *, require_transfer_tail: bool = True) -> Tuple[str, str]:
         raw_method = str((data or {}).get("payment_method") or self.PAYMENT_METHOD_CASH).strip().lower()
         method_aliases = {
@@ -594,6 +617,44 @@ class AppController:
         if method == cls.PAYMENT_METHOD_TRANSFER:
             return "轉帳"
         return "現金"
+
+    def _normalize_receipt_fields(self, data: Dict[str, Any]) -> Tuple[str, str]:
+        raw_method = str((data or {}).get("receipt_method") or self.RECEIPT_METHOD_ELECTRONIC).strip().upper()
+        aliases = {
+            "ELECTRONIC": self.RECEIPT_METHOD_ELECTRONIC,
+            "SYSTEM": self.RECEIPT_METHOD_ELECTRONIC,
+            "電子": self.RECEIPT_METHOD_ELECTRONIC,
+            "電子收據": self.RECEIPT_METHOD_ELECTRONIC,
+            "PAPER": self.RECEIPT_METHOD_PAPER,
+            "紙本": self.RECEIPT_METHOD_PAPER,
+            "紙本收據": self.RECEIPT_METHOD_PAPER,
+        }
+        method = aliases.get(raw_method)
+        if method not in {self.RECEIPT_METHOD_ELECTRONIC, self.RECEIPT_METHOD_PAPER}:
+            raise ValueError("收據型態必須為電子收據或紙本收據")
+        paper_no = str((data or {}).get("paper_receipt_number") or "").strip()
+        if method == self.RECEIPT_METHOD_PAPER and not paper_no:
+            raise ValueError("紙本收據必須填寫紙本收據號")
+        return method, paper_no if method == self.RECEIPT_METHOD_PAPER else ""
+
+    @classmethod
+    def _receipt_method_label(cls, value: Any) -> str:
+        method = str(value or cls.RECEIPT_METHOD_ELECTRONIC).strip().upper()
+        if method == cls.RECEIPT_METHOD_PAPER:
+            return "紙本收據"
+        return "電子收據"
+
+    @staticmethod
+    def _append_paper_receipt_note(note: str, paper_receipt_number: str) -> str:
+        base = str(note or "").strip()
+        paper_no = str(paper_receipt_number or "").strip()
+        if not paper_no:
+            return base
+        marker = "紙本收據號："
+        segment = f"{marker}{paper_no}"
+        if marker in base:
+            return re.sub(r"紙本收據號：[^｜]*", segment, base)
+        return f"{base}｜{segment}" if base else segment
 
     @staticmethod
     def _parse_ymd_to_date(text: Optional[str]) -> Optional[date]:
@@ -874,6 +935,7 @@ class AppController:
         return
 
     def list_lighting_signups(self, signup_year: int, keyword: str = "", unpaid_only: bool = False) -> List[Dict[str, Any]]:
+        self._ensure_business_receipt_schema()
         year_value = int(signup_year)
         kw = (keyword or "").strip()
         cur = self.conn.cursor()
@@ -890,6 +952,8 @@ class AppController:
                 COALESCE(s.is_paid, 0) AS is_paid,
                 s.paid_at,
                 s.payment_receipt_number,
+                COALESCE(s.receipt_method, 'ELECTRONIC') AS receipt_method,
+                COALESCE(s.paper_receipt_number, '') AS paper_receipt_number,
                 GROUP_CONCAT(i.lighting_item_name, '、') AS lighting_summary
             FROM lighting_signups s
             JOIN people p ON p.id = s.person_id
@@ -1561,11 +1625,17 @@ class AppController:
         handler: str = "",
         payment_method: str = "cash",
         transfer_last5: str = "",
+        receipt_method: str = "ELECTRONIC",
+        paper_receipt_number: str = "",
     ) -> Dict[str, Any]:
         payment_method, transfer_last5 = self._normalize_payment_fields(
             {"payment_method": payment_method, "transfer_last5": transfer_last5}
         )
         self._ensure_transactions_payment_schema()
+        self._ensure_business_receipt_schema()
+        receipt_method, paper_receipt_number = self._normalize_receipt_fields(
+            {"receipt_method": receipt_method, "paper_receipt_number": paper_receipt_number}
+        )
         normalized_ids = [str(x).strip() for x in (signup_ids or []) if str(x).strip()]
         if not normalized_ids:
             return {"paid_count": 0, "skipped_count": 0, "receipt_numbers": []}
@@ -1629,34 +1699,46 @@ class AppController:
                 adjustment_kind = "SUPPLEMENT" if signup_kind == "APPEND" else "PRIMARY"
                 receipt = self.generate_receipt_number(today)
                 note = f"[{signup_year - 1911}年安燈] {str(row.get('lighting_summary') or '').strip()}".strip()
+                note = self._append_paper_receipt_note(note, paper_receipt_number)
                 cur.execute(
                     """
                     INSERT INTO transactions (
                         date, type, category_id, category_name, amount,
                         payer_person_id, payer_name, handler, receipt_number, note,
-                        payment_method, transfer_last5,
+                        payment_method, transfer_last5, receipt_method, paper_receipt_number,
                         source_type, source_id, adjustment_kind, adjusts_txn_id, is_system_generated
-                    ) VALUES (?, 'income', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, 'income', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         today, category_id, category_name, int(row.get("total_amount") or 0),
                         str(row.get("person_id") or ""), str(row.get("person_name") or ""),
                         handler_text, receipt, note,
-                        payment_method, transfer_last5,
+                        payment_method, transfer_last5, receipt_method, paper_receipt_number,
                         "LIGHTING_SIGNUP", str(row.get("signup_id") or ""), adjustment_kind, None, 1,
                     ),
                 )
                 txn_id = cur.lastrowid
                 cur.execute(
-                    "UPDATE lighting_signups SET is_paid = 1, paid_at = ?, payment_txn_id = ?, payment_receipt_number = ?, updated_at = ? WHERE id = ?",
-                    (now, int(txn_id or 0), receipt, now, str(row.get("signup_id") or "")),
+                    """
+                    UPDATE lighting_signups
+                    SET is_paid = 1,
+                        paid_at = ?,
+                        payment_txn_id = ?,
+                        payment_receipt_number = ?,
+                        receipt_method = ?,
+                        paper_receipt_number = ?,
+                        updated_at = ?
+                    WHERE id = ?
+                    """,
+                    (now, int(txn_id or 0), receipt, receipt_method, paper_receipt_number, now, str(row.get("signup_id") or "")),
                 )
                 paid_count += 1
                 receipts.append(receipt)
                 paid_details.append(
                     f"{str(row.get('person_name') or '-')}（person_id {str(row.get('person_id') or '-')}, "
                     f"signup_id {str(row.get('signup_id') or '-')}, kind {signup_kind}, "
-                    f"金額 {int(row.get('total_amount') or 0)}, 收據 {receipt}）"
+                    f"金額 {int(row.get('total_amount') or 0)}, 收據 {receipt}，"
+                    f"收據型態 {self._receipt_method_label(receipt_method)}，紙本收據 {paper_receipt_number or '-'}）"
                 )
             cur.execute("COMMIT;")
         except Exception as e:
@@ -5112,6 +5194,7 @@ class AppController:
 
 
     def get_activity_signups(self, activity_id):
+        self._ensure_business_receipt_schema()
         sql = """
         SELECT
             s.id AS signup_id,
@@ -5129,6 +5212,8 @@ class AppController:
             COALESCE(s.is_paid, 0) AS is_paid,
             s.paid_at,
             s.payment_receipt_number,
+            COALESCE(s.receipt_method, 'ELECTRONIC') AS receipt_method,
+            COALESCE(s.paper_receipt_number, '') AS paper_receipt_number,
             GROUP_CONCAT(
                 CASE
                     WHEN ap.price_type = 'FREE'
@@ -5211,12 +5296,18 @@ class AppController:
         handler: str = "",
         payment_method: str = "cash",
         transfer_last5: str = "",
+        receipt_method: str = "ELECTRONIC",
+        paper_receipt_number: str = "",
     ) -> Dict[str, Any]:
         aid = (activity_id or "").strip()
         payment_method, transfer_last5 = self._normalize_payment_fields(
             {"payment_method": payment_method, "transfer_last5": transfer_last5}
         )
         self._ensure_transactions_payment_schema()
+        self._ensure_business_receipt_schema()
+        receipt_method, paper_receipt_number = self._normalize_receipt_fields(
+            {"receipt_method": receipt_method, "paper_receipt_number": paper_receipt_number}
+        )
         normalized_ids = [str(x).strip() for x in (signup_ids or []) if str(x).strip()]
         if not aid:
             self._log_activity_system_event("活動報名繳費失敗（原因：activity_id 為空）", level="WARN")
@@ -5308,14 +5399,15 @@ class AppController:
                 activity_end_date = ad_to_roc_string(str(row.get("activity_end_date") or "").strip(), separator="/")
                 activity_label = f"{activity_end_date} {activity_name}".strip() if activity_end_date else activity_name
                 note = f"[{activity_label}] {plan_summary}".strip() if plan_summary else f"[{activity_label}]"
+                note = self._append_paper_receipt_note(note, paper_receipt_number)
                 cur.execute(
                     """
                     INSERT INTO transactions (
                         date, type, category_id, category_name, amount,
                         payer_person_id, payer_name, handler, receipt_number, note,
-                        payment_method, transfer_last5,
+                        payment_method, transfer_last5, receipt_method, paper_receipt_number,
                         source_type, source_id, adjustment_kind, adjusts_txn_id, is_system_generated
-                    ) VALUES (?, 'income', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, 'income', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         today,
@@ -5329,6 +5421,8 @@ class AppController:
                         note,
                         payment_method,
                         transfer_last5,
+                        receipt_method,
+                        paper_receipt_number,
                         "ACTIVITY_SIGNUP",
                         str(row.get("signup_id") or ""),
                         adjustment_kind,
@@ -5344,17 +5438,20 @@ class AppController:
                         paid_at = ?,
                         payment_txn_id = ?,
                         payment_receipt_number = ?,
+                        receipt_method = ?,
+                        paper_receipt_number = ?,
                         updated_at = ?
                     WHERE id = ?
                     """,
-                    (now, int(txn_id or 0), receipt, now, str(row.get("signup_id") or "")),
+                    (now, int(txn_id or 0), receipt, receipt_method, paper_receipt_number, now, str(row.get("signup_id") or "")),
                 )
                 paid_count += 1
                 receipt_numbers.append(receipt)
                 paid_details.append(
                     f"{str(row.get('person_name') or '-')}（person_id {str(row.get('person_id') or '-')}, "
                     f"signup_id {str(row.get('signup_id') or '-')}, kind {signup_kind}, "
-                    f"金額 {int(row.get('total_amount') or 0)}, 收據 {receipt}）"
+                    f"金額 {int(row.get('total_amount') or 0)}, 收據 {receipt}，"
+                    f"收據型態 {self._receipt_method_label(receipt_method)}，紙本收據 {paper_receipt_number or '-'}）"
                 )
 
             cur.execute("COMMIT;")
@@ -6406,10 +6503,16 @@ class AppController:
              self._log_finance_system_event("新增收入資料警示（payer_person_id 未提供）", level="WARN")
 
         self._ensure_transactions_payment_schema()
+        self._ensure_business_receipt_schema()
         payment_method, transfer_last5 = self._normalize_payment_fields(data)
+        receipt_method, paper_receipt_number = self._normalize_receipt_fields(data)
         data = dict(data or {})
         data["payment_method"] = payment_method
         data["transfer_last5"] = transfer_last5
+        data["receipt_method"] = receipt_method
+        data["paper_receipt_number"] = paper_receipt_number
+        if receipt_method == self.RECEIPT_METHOD_PAPER:
+            data["note"] = self._append_paper_receipt_note(data.get("note"), paper_receipt_number)
 
         cursor = self.conn.cursor()
         try:
@@ -6417,9 +6520,9 @@ class AppController:
             INSERT INTO transactions (
                 date, type, category_id, category_name, amount, 
                 payer_person_id, payer_name, handler, receipt_number, note,
-                payment_method, transfer_last5,
+                payment_method, transfer_last5, receipt_method, paper_receipt_number,
                 source_type, source_id, adjustment_kind, adjusts_txn_id, is_system_generated
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             data.get("date"),
             data.get("type"),
@@ -6433,6 +6536,8 @@ class AppController:
             data.get("note"),
             data.get("payment_method"),
             data.get("transfer_last5"),
+            data.get("receipt_method"),
+            data.get("paper_receipt_number"),
             data.get("source_type"),
             data.get("source_id"),
             data.get("adjustment_kind"),
@@ -6450,8 +6555,9 @@ class AppController:
         self._log_transaction_change(f"{action_prefix}.CREATE", tx_id, data=data, before=None)
         return tx_id
     
-    def get_transactions(self, transaction_type=None, start_date=None, end_date=None, keyword=None, voided_filter="all"):
+    def get_transactions(self, transaction_type=None, start_date=None, end_date=None, keyword=None, voided_filter="all", receipt_filter="all"):
         cursor = self.conn.cursor()
+        self._ensure_business_receipt_schema()
         query = """
             SELECT t.*, p.phone_mobile, p.address
             FROM transactions t
@@ -6486,6 +6592,12 @@ class AppController:
             params.extend([kw, kw, kw, kw, kw])
 
         cols = self._table_columns("transactions") if self._table_exists("transactions") else []
+        if "receipt_method" in cols:
+            receipt_mode = str(receipt_filter or "all").strip().lower()
+            if receipt_mode == "paper":
+                query += " AND COALESCE(t.receipt_method, 'ELECTRONIC') = 'PAPER'"
+            elif receipt_mode == "electronic":
+                query += " AND COALESCE(t.receipt_method, 'ELECTRONIC') = 'ELECTRONIC'"
         if "is_voided" in cols:
             mode = str(voided_filter or "all").strip().lower()
             if mode == "exclude":
@@ -6497,6 +6609,56 @@ class AppController:
         
         cursor.execute(query, tuple(params))
         return [dict(row) for row in cursor.fetchall()]
+
+    def update_transaction_paper_receipt_number(self, transaction_id, paper_receipt_number: str) -> bool:
+        self._ensure_business_receipt_schema()
+        paper_no = str(paper_receipt_number or "").strip()
+        if not paper_no:
+            raise ValueError("紙本收據號不可空白")
+        cur = self.conn.cursor()
+        row = cur.execute(
+            "SELECT * FROM transactions WHERE id=? AND (is_deleted=0 OR is_deleted IS NULL)",
+            (transaction_id,),
+        ).fetchone()
+        if not row:
+            raise ValueError("交易不存在或已刪除")
+        tx = dict(row)
+        if int(tx.get("is_voided") or 0) == 1:
+            raise ValueError("作廢單據不可修改紙本收據號")
+        if str(tx.get("type") or "").strip().lower() != "income":
+            raise ValueError("僅收入資料可補紙本收據號")
+        if str(tx.get("receipt_method") or self.RECEIPT_METHOD_ELECTRONIC).strip().upper() != self.RECEIPT_METHOD_PAPER:
+            raise ValueError("僅紙本收據交易可補紙本收據號")
+
+        note = self._append_paper_receipt_note(str(tx.get("note") or ""), paper_no)
+        source_type = str(tx.get("source_type") or "").strip().upper()
+        source_id = str(tx.get("source_id") or "").strip()
+        try:
+            cur.execute("BEGIN;")
+            cur.execute(
+                "UPDATE transactions SET paper_receipt_number=?, note=? WHERE id=?",
+                (paper_no, note, transaction_id),
+            )
+            if source_type == "ACTIVITY_SIGNUP" and source_id and self._table_exists("activity_signups"):
+                cur.execute(
+                    "UPDATE activity_signups SET paper_receipt_number=?, updated_at=? WHERE id=?",
+                    (paper_no, self._now(), source_id),
+                )
+            elif source_type == "LIGHTING_SIGNUP" and source_id and self._table_exists("lighting_signups"):
+                cur.execute(
+                    "UPDATE lighting_signups SET paper_receipt_number=?, updated_at=? WHERE id=?",
+                    (paper_no, self._now(), source_id),
+                )
+            cur.execute("COMMIT;")
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+
+        after = dict(tx)
+        after["paper_receipt_number"] = paper_no
+        after["note"] = note
+        self._log_transaction_change("INCOME.UPDATE", transaction_id, data=after, before=tx)
+        return True
 
     def list_transactions_by_source(self, source_type: str, source_id: str) -> List[Dict[str, Any]]:
         """

--- a/app/database/setup_db.py
+++ b/app/database/setup_db.py
@@ -318,6 +318,8 @@ def create_activity_signups_table(db_name=DB_NAME):
     paid_at TEXT,
     payment_txn_id INTEGER,
     payment_receipt_number TEXT,
+    receipt_method TEXT DEFAULT 'ELECTRONIC',
+    paper_receipt_number TEXT,
 
     created_at TEXT DEFAULT (datetime('now', 'localtime')),
     updated_at TEXT DEFAULT (datetime('now', 'localtime')),
@@ -358,6 +360,8 @@ def create_transactions_table(db_name=DB_NAME):
         receipt_number TEXT, -- 收據號碼
         payment_method TEXT DEFAULT 'cash', -- cash / transfer
         transfer_last5 TEXT, -- 轉帳末5碼
+        receipt_method TEXT DEFAULT 'ELECTRONIC', -- ELECTRONIC / PAPER
+        paper_receipt_number TEXT, -- 紙本收據號
         note TEXT,
         is_voided INTEGER DEFAULT 0, -- 作廢標記 (0=正常, 1=作廢)
         source_type TEXT, -- 來源類型：LIGHTING_SIGNUP / ACTIVITY_SIGNUP / MANUAL
@@ -422,6 +426,8 @@ def create_lighting_signup_tables(db_name=DB_NAME):
         paid_at TEXT,
         payment_txn_id INTEGER,
         payment_receipt_number TEXT,
+        receipt_method TEXT DEFAULT 'ELECTRONIC',
+        paper_receipt_number TEXT,
         created_at TEXT DEFAULT (datetime('now', 'localtime')),
         updated_at TEXT DEFAULT (datetime('now', 'localtime'))
     )

--- a/app/dialogs/income_expense_dialog.py
+++ b/app/dialogs/income_expense_dialog.py
@@ -554,7 +554,7 @@ class TransactionTab(QWidget):
         self.table.setColumnWidth(7, 120)  # 經手人
         self.table.setColumnWidth(8, 70)   # 作廢
         self.table.setColumnWidth(9, 100)  # 類型
-        self.table.setColumnWidth(10, 320) # 摘要
+        self.table.setColumnWidth(10, 520) # 摘要
         self.table.setSelectionBehavior(QTableWidget.SelectRows)
         self.table.setEditTriggers(QTableWidget.NoEditTriggers)
         self.table.setStyleSheet(
@@ -903,7 +903,9 @@ class TransactionTab(QWidget):
             self.table.setItem(i, 7, QTableWidgetItem(row['handler']))
             self.table.setItem(i, 8, QTableWidgetItem("作廢" if int((row or {}).get("is_voided") or 0) == 1 else ""))
             self.table.setItem(i, 9, QTableWidgetItem(self._format_adjustment_kind_label(row)))
-            self.table.setItem(i, 10, QTableWidgetItem(row['note']))
+            note_item = QTableWidgetItem(row['note'])
+            note_item.setToolTip(str(row.get("note") or ""))
+            self.table.setItem(i, 10, note_item)
             
             # 將整筆資料存入第一欄的 UserRole，供修改/刪除/列印使用
             self.table.item(i, 0).setData(Qt.UserRole, row)

--- a/app/dialogs/income_expense_dialog.py
+++ b/app/dialogs/income_expense_dialog.py
@@ -2,7 +2,7 @@ import calendar
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton, 
     QComboBox, QDateEdit, QTabWidget, QWidget, QMessageBox, QFormLayout,
-    QTableWidget, QTableWidgetItem, QHeaderView, QSplitter, QFrame, QListView, QAbstractSpinBox
+    QTableWidget, QTableWidgetItem, QHeaderView, QSplitter, QFrame, QListView, QAbstractSpinBox, QInputDialog
 )
 from PyQt5.QtCore import QDate, Qt, pyqtSignal
 from PyQt5.QtGui import QColor
@@ -274,6 +274,7 @@ class TransactionTab(QWidget):
         self.selected_person_id = None
         self.show_all_mode = False
         self.void_only_mode = False
+        self.paper_receipt_only_mode = False
         
         self.init_ui()
         self.load_initial_data()
@@ -324,6 +325,11 @@ class TransactionTab(QWidget):
         self.btn_void_only = QPushButton("作廢單據")
         self.btn_void_only.setCheckable(True)
         self.btn_void_only.toggled.connect(self.toggle_void_only)
+        self.btn_paper_receipt_only = QPushButton("紙本收據")
+        self.btn_paper_receipt_only.setCheckable(True)
+        self.btn_paper_receipt_only.toggled.connect(self.toggle_paper_receipt_only)
+        if self.t_type != "income":
+            self.btn_paper_receipt_only.setVisible(False)
         
         # 排序
         # self.sort_combo = QComboBox()
@@ -502,6 +508,7 @@ class TransactionTab(QWidget):
         action_row.addWidget(self.btn_list_search)
         action_row.addWidget(self.btn_list_clear)
         action_row.addWidget(self.btn_void_only)
+        action_row.addWidget(self.btn_paper_receipt_only)
         action_row.addStretch()
 
         self.btn_edit_row = QPushButton("修改資料")
@@ -516,11 +523,14 @@ class TransactionTab(QWidget):
         )
         self.btn_print_row = None
         self.btn_void_row = None
+        self.btn_edit_paper_receipt_row = None
         if self.t_type == "income":
             self.btn_print_row = QPushButton("補印收據")
             self.btn_print_row.clicked.connect(self._print_selected_row)
             self.btn_void_row = QPushButton("作廢")
             self.btn_void_row.clicked.connect(self._void_selected_row)
+            self.btn_edit_paper_receipt_row = QPushButton("補紙本收據號")
+            self.btn_edit_paper_receipt_row.clicked.connect(self._edit_paper_receipt_number)
 
         self.btn_edit_row.clicked.connect(self._edit_selected_row)
         self.btn_del_row.clicked.connect(self._delete_selected_row)
@@ -569,6 +579,8 @@ class TransactionTab(QWidget):
             bottom_action_row.addWidget(self.btn_print_row)
         if self.btn_void_row is not None:
             bottom_action_row.addWidget(self.btn_void_row)
+        if self.btn_edit_paper_receipt_row is not None:
+            bottom_action_row.addWidget(self.btn_edit_paper_receipt_row)
         bottom_action_row.addWidget(self.btn_edit_row)
         bottom_action_row.addWidget(self.btn_del_row)
         
@@ -813,9 +825,15 @@ class TransactionTab(QWidget):
         self.btn_void_only.setText("顯示全部" if checked else "作廢單據")
         self.refresh_list()
 
+    def toggle_paper_receipt_only(self, checked):
+        self.paper_receipt_only_mode = bool(checked)
+        self.btn_paper_receipt_only.setText("顯示全部" if checked else "紙本收據")
+        self.refresh_list()
+
     def refresh_list(self):
         self._reload_category_items(keep_selection=True)
         keyword = self.list_search_input.text().strip() if hasattr(self, "list_search_input") else None
+        receipt_filter = "paper" if self.paper_receipt_only_mode else "all"
         if self._is_income_limited_scope():
             curr = QDate.currentDate()
             prev = curr.addMonths(-1)
@@ -827,6 +845,7 @@ class TransactionTab(QWidget):
                 end_date=None,
                 keyword=keyword,
                 voided_filter="only" if self.void_only_mode else "all",
+                receipt_filter=receipt_filter,
             )
             start_dt = date(prev.year(), prev.month(), 1)
             end_dt = date(curr.year(), curr.month(), curr.day())
@@ -842,6 +861,7 @@ class TransactionTab(QWidget):
                 end_date=None,
                 keyword=keyword,
                 voided_filter="only",
+                receipt_filter=receipt_filter,
             )
         elif self.show_all_mode:
             data = self.controller.get_transactions(
@@ -849,6 +869,7 @@ class TransactionTab(QWidget):
                 start_date=None,
                 end_date=None,
                 keyword=keyword,
+                receipt_filter=receipt_filter,
             )
         else:
             year = self.year_combo.currentData()
@@ -867,6 +888,7 @@ class TransactionTab(QWidget):
                 start_date,
                 end_date,
                 keyword=keyword,
+                receipt_filter=receipt_filter,
             )
         
         self.table.setRowCount(len(data))
@@ -1071,6 +1093,15 @@ class TransactionTab(QWidget):
             return False
         return True
 
+    def _can_edit_paper_receipt_number(self, data):
+        if self.t_type != "income" or not data:
+            return False
+        if int((data or {}).get("is_voided") or 0) == 1:
+            return False
+        if not self._has_income_row_write_permission():
+            return False
+        return str((data or {}).get("receipt_method") or "").strip().upper() == "PAPER"
+
     def _show_system_income_lock_message(self):
         QMessageBox.information(
             self,
@@ -1101,6 +1132,14 @@ class TransactionTab(QWidget):
             self.btn_del_row.setToolTip("")
         if self.btn_print_row is not None:
             self.btn_print_row.setEnabled(has_row)
+        if self.btn_edit_paper_receipt_row is not None:
+            self.btn_edit_paper_receipt_row.setEnabled(has_row and self._can_edit_paper_receipt_number(data))
+            if has_row and int((data or {}).get("is_voided") or 0) == 1:
+                self.btn_edit_paper_receipt_row.setToolTip("作廢單據不可修改紙本收據號。")
+            elif has_row and str((data or {}).get("receipt_method") or "").strip().upper() != "PAPER":
+                self.btn_edit_paper_receipt_row.setToolTip("僅紙本收據交易可補紙本收據號。")
+            else:
+                self.btn_edit_paper_receipt_row.setToolTip("")
 
     def _edit_selected_row(self):
         data = self._get_selected_row_data()
@@ -1178,6 +1217,35 @@ class TransactionTab(QWidget):
         except Exception as e:
             QMessageBox.warning(self, "作廢失敗", str(e))
 
+    def _edit_paper_receipt_number(self):
+        data = self._get_selected_row_data()
+        if not data:
+            QMessageBox.warning(self, "提示", "請先選取一筆資料")
+            return
+        if not self._can_edit_paper_receipt_number(data):
+            QMessageBox.information(self, "限制", "僅紙本收據交易可補紙本收據號。")
+            return
+        current_no = str((data or {}).get("paper_receipt_number") or "").strip()
+        value, ok = QInputDialog.getText(
+            self,
+            "補紙本收據號",
+            "紙本收據號：",
+            QLineEdit.Normal,
+            current_no,
+        )
+        if not ok:
+            return
+        paper_no = (value or "").strip()
+        if not paper_no:
+            QMessageBox.information(self, "欄位不足", "請輸入紙本收據號。")
+            return
+        try:
+            self.controller.update_transaction_paper_receipt_number(data["id"], paper_no)
+            QMessageBox.information(self, "完成", "紙本收據號已更新。")
+            self.refresh_list()
+        except Exception as e:
+            QMessageBox.warning(self, "更新失敗", str(e))
+
     def show_context_menu(self, pos):
         item = self.table.itemAt(pos)
         if not item:
@@ -1224,6 +1292,10 @@ class TransactionTab(QWidget):
             void_action.triggered.connect(lambda: self._void_selected_row())
             void_action.setEnabled(self._can_void_data(data))
             menu.addAction(void_action)
+            paper_action = QAction("補紙本收據號", self)
+            paper_action.triggered.connect(lambda: self._edit_paper_receipt_number())
+            paper_action.setEnabled(self._can_edit_paper_receipt_number(data))
+            menu.addAction(paper_action)
             menu.addSeparator()
 
         edit_action = QAction("修改資料", self)

--- a/app/dialogs/income_expense_dialog.py
+++ b/app/dialogs/income_expense_dialog.py
@@ -320,12 +320,12 @@ class TransactionTab(QWidget):
         self.list_search_input.returnPressed.connect(self.apply_list_search)
         self.btn_list_search = QPushButton("搜尋")
         self.btn_list_search.clicked.connect(self.apply_list_search)
-        self.btn_list_clear = QPushButton("清除")
+        self.btn_list_clear = QPushButton("清除篩選")
         self.btn_list_clear.clicked.connect(self.clear_list_search)
-        self.btn_void_only = QPushButton("作廢單據")
+        self.btn_void_only = QPushButton("只看作廢")
         self.btn_void_only.setCheckable(True)
         self.btn_void_only.toggled.connect(self.toggle_void_only)
-        self.btn_paper_receipt_only = QPushButton("紙本收據")
+        self.btn_paper_receipt_only = QPushButton("只看紙本")
         self.btn_paper_receipt_only.setCheckable(True)
         self.btn_paper_receipt_only.toggled.connect(self.toggle_paper_receipt_only)
         if self.t_type != "income":
@@ -818,16 +818,25 @@ class TransactionTab(QWidget):
 
     def clear_list_search(self):
         self.list_search_input.clear()
+        if hasattr(self, "btn_void_only"):
+            self.btn_void_only.blockSignals(True)
+            self.btn_void_only.setChecked(False)
+            self.btn_void_only.blockSignals(False)
+        if hasattr(self, "btn_paper_receipt_only"):
+            self.btn_paper_receipt_only.blockSignals(True)
+            self.btn_paper_receipt_only.setChecked(False)
+            self.btn_paper_receipt_only.blockSignals(False)
+
+        self.void_only_mode = False
+        self.paper_receipt_only_mode = False
         self.refresh_list()
 
     def toggle_void_only(self, checked):
         self.void_only_mode = bool(checked)
-        self.btn_void_only.setText("顯示全部" if checked else "作廢單據")
         self.refresh_list()
 
     def toggle_paper_receipt_only(self, checked):
         self.paper_receipt_only_mode = bool(checked)
-        self.btn_paper_receipt_only.setText("顯示全部" if checked else "紙本收據")
         self.refresh_list()
 
     def refresh_list(self):

--- a/app/dialogs/payment_method_dialog.py
+++ b/app/dialogs/payment_method_dialog.py
@@ -46,21 +46,26 @@ class PaymentMethodDialog(QDialog):
         self.transfer_last5_input.setPlaceholderText("轉帳末5碼")
         self.transfer_last5_input.setVisible(False)
         self.method_combo.currentIndexChanged.connect(self._sync_transfer_field)
+        self.transfer_last5_label = QLabel("轉帳末5碼")
+        self.transfer_last5_label.setVisible(False)
 
         self.receipt_method_combo = QComboBox()
         self.receipt_method_combo.addItem("電子收據", "ELECTRONIC")
         self.receipt_method_combo.addItem("紙本收據", "PAPER")
+        self.receipt_method_combo.setMinimumWidth(180)
         self.paper_receipt_number_input = QLineEdit()
         self.paper_receipt_number_input.setPlaceholderText("紙本收據號")
         self.paper_receipt_number_input.setVisible(False)
         self.receipt_method_combo.currentIndexChanged.connect(self._sync_paper_receipt_field)
+        self.paper_receipt_number_label = QLabel("紙本收據號")
+        self.paper_receipt_number_label.setVisible(False)
 
         form.addRow("本次繳費", self.summary_label)
         form.addRow("經手人", self.handler_input)
         form.addRow("付款方式", self.method_combo)
-        form.addRow("轉帳末5碼", self.transfer_last5_input)
+        form.addRow(self.transfer_last5_label, self.transfer_last5_input)
         form.addRow("收據型態", self.receipt_method_combo)
-        form.addRow("紙本收據號", self.paper_receipt_number_input)
+        form.addRow(self.paper_receipt_number_label, self.paper_receipt_number_input)
         layout.addLayout(form)
 
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
@@ -76,12 +81,14 @@ class PaymentMethodDialog(QDialog):
 
     def _sync_transfer_field(self):
         is_transfer = self.method_combo.currentData() == "transfer"
+        self.transfer_last5_label.setVisible(is_transfer)
         self.transfer_last5_input.setVisible(is_transfer)
         if not is_transfer:
             self.transfer_last5_input.clear()
 
     def _sync_paper_receipt_field(self):
         is_paper = self.receipt_method_combo.currentData() == "PAPER"
+        self.paper_receipt_number_label.setVisible(is_paper)
         self.paper_receipt_number_input.setVisible(is_paper)
         if not is_paper:
             self.paper_receipt_number_input.clear()

--- a/app/dialogs/payment_method_dialog.py
+++ b/app/dialogs/payment_method_dialog.py
@@ -47,10 +47,20 @@ class PaymentMethodDialog(QDialog):
         self.transfer_last5_input.setVisible(False)
         self.method_combo.currentIndexChanged.connect(self._sync_transfer_field)
 
+        self.receipt_method_combo = QComboBox()
+        self.receipt_method_combo.addItem("電子收據", "ELECTRONIC")
+        self.receipt_method_combo.addItem("紙本收據", "PAPER")
+        self.paper_receipt_number_input = QLineEdit()
+        self.paper_receipt_number_input.setPlaceholderText("紙本收據號")
+        self.paper_receipt_number_input.setVisible(False)
+        self.receipt_method_combo.currentIndexChanged.connect(self._sync_paper_receipt_field)
+
         form.addRow("本次繳費", self.summary_label)
         form.addRow("經手人", self.handler_input)
         form.addRow("付款方式", self.method_combo)
         form.addRow("轉帳末5碼", self.transfer_last5_input)
+        form.addRow("收據型態", self.receipt_method_combo)
+        form.addRow("紙本收據號", self.paper_receipt_number_input)
         layout.addLayout(form)
 
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
@@ -70,6 +80,12 @@ class PaymentMethodDialog(QDialog):
         if not is_transfer:
             self.transfer_last5_input.clear()
 
+    def _sync_paper_receipt_field(self):
+        is_paper = self.receipt_method_combo.currentData() == "PAPER"
+        self.paper_receipt_number_input.setVisible(is_paper)
+        if not is_paper:
+            self.paper_receipt_number_input.clear()
+
     def _accept_if_valid(self):
         handler = (self.handler_input.text() or "").strip()
         if not handler:
@@ -82,10 +98,18 @@ class PaymentMethodDialog(QDialog):
             QMessageBox.information(self, "欄位不足", "轉帳付款必須填寫末5碼。")
             return
 
+        receipt_method = self.receipt_method_combo.currentData() or "ELECTRONIC"
+        paper_receipt_number = (self.paper_receipt_number_input.text() or "").strip()
+        if receipt_method == "PAPER" and not paper_receipt_number:
+            QMessageBox.information(self, "欄位不足", "紙本收據必須填寫紙本收據號。")
+            return
+
         self._payload = {
             "handler": handler,
             "payment_method": method,
             "transfer_last5": transfer_last5 if method == "transfer" else "",
+            "receipt_method": receipt_method,
+            "paper_receipt_number": paper_receipt_number if receipt_method == "PAPER" else "",
         }
         self.accept()
 

--- a/app/dialogs/payment_method_dialog.py
+++ b/app/dialogs/payment_method_dialog.py
@@ -54,7 +54,7 @@ class PaymentMethodDialog(QDialog):
         self.receipt_method_combo.addItem("紙本收據", "PAPER")
         self.receipt_method_combo.setMinimumWidth(180)
         self.paper_receipt_number_input = QLineEdit()
-        self.paper_receipt_number_input.setPlaceholderText("紙本收據號")
+        self.paper_receipt_number_input.setPlaceholderText("紙本收據號（可事後補）")
         self.paper_receipt_number_input.setVisible(False)
         self.receipt_method_combo.currentIndexChanged.connect(self._sync_paper_receipt_field)
         self.paper_receipt_number_label = QLabel("紙本收據號")
@@ -107,9 +107,6 @@ class PaymentMethodDialog(QDialog):
 
         receipt_method = self.receipt_method_combo.currentData() or "ELECTRONIC"
         paper_receipt_number = (self.paper_receipt_number_input.text() or "").strip()
-        if receipt_method == "PAPER" and not paper_receipt_number:
-            QMessageBox.information(self, "欄位不足", "紙本收據必須填寫紙本收據號。")
-            return
 
         self._payload = {
             "handler": handler,

--- a/app/utils/print_helper.py
+++ b/app/utils/print_helper.py
@@ -1037,8 +1037,18 @@ class PrintHelper:
         # 1. 標題: 感謝狀 (10%)
         draw_v_text("感謝狀", 10, Y_TITLE, FONT_TITLE, spacing=1.1, bold=True)
         
+        raw_note = str(data.get('note', '') or '')
+        paper_receipt_number = str(data.get('paper_receipt_number', '') or '').strip()
+        if not paper_receipt_number and raw_note:
+            match = re.search(r"紙本收據號：([^｜\n\r]+)", raw_note)
+            if match:
+                paper_receipt_number = match.group(1).strip()
+
+        summary_text = raw_note or data.get('category_name', '')
+        if summary_text:
+            summary_text = re.sub(r"(?:\s*｜\s*)?紙本收據號：[^｜\n\r]+", "", summary_text).strip()
+
         # --- 感謝狀右上角摘要 ---
-        summary_text = data.get('note', '') or data.get('category_name', '')
         if summary_text:
             painter.save()
             set_font(12, bold=True)
@@ -1144,12 +1154,38 @@ class PrintHelper:
         # B. 無效聲明 (原橫式已移除)
         
         # C. 收據編號 No. (右下, 紅色)
+        receipt_text = f"No. {data.get('receipt_number', '')}"
         set_font(16, bold=True)
         painter.setPen(Qt.red)
         # 在 copy title 上方，靠右（再上移，避免與報稅框重疊）
         rect_no = QRectF(content_rect.right() - (50 * unit), content_rect.bottom() - (12.2 * unit),
                          45 * unit, 6 * unit)
-        painter.drawText(rect_no, Qt.AlignRight | Qt.AlignVCenter, f"No. {data.get('receipt_number', '')}")
+        painter.drawText(rect_no, Qt.AlignRight | Qt.AlignVCenter, receipt_text)
+
+        if paper_receipt_number:
+            paper_receipt_text = f"No. {paper_receipt_number}"
+            painter.setPen(Qt.black)
+            fm_paper_no = painter.fontMetrics()
+            paper_no_w = fm_paper_no.horizontalAdvance(paper_receipt_text)
+            paper_no_x = rect_no.right() - paper_no_w
+
+            rect_paper_no = QRectF(
+                paper_no_x,
+                rect_no.top() - (3.9 * unit),
+                paper_no_w,
+                6 * unit,
+            )
+            painter.drawText(rect_paper_no, Qt.AlignLeft | Qt.AlignVCenter, paper_receipt_text)
+
+            set_font(10, bold=True)
+            rect_paper_label = QRectF(
+                paper_no_x,
+                rect_paper_no.top() - (1.9 * unit),
+                paper_no_w,
+                3.5 * unit,
+            )
+            painter.drawText(rect_paper_label, Qt.AlignLeft | Qt.AlignVCenter, "紙本收據")
+            painter.setPen(Qt.red)
         painter.setPen(Qt.black)
 
         if show_tax_id:

--- a/app/widgets/activity_signup_page.py
+++ b/app/widgets/activity_signup_page.py
@@ -866,6 +866,8 @@ class ActivitySignupPage(QWidget):
                 handler=payment_fields.get("handler", ""),
                 payment_method=payment_fields.get("payment_method", "cash"),
                 transfer_last5=payment_fields.get("transfer_last5", ""),
+                receipt_method=payment_fields.get("receipt_method", "ELECTRONIC"),
+                paper_receipt_number=payment_fields.get("paper_receipt_number", ""),
             )
         except Exception as e:
             QMessageBox.warning(self, "繳費失敗", str(e))

--- a/app/widgets/lighting_signup_page.py
+++ b/app/widgets/lighting_signup_page.py
@@ -922,6 +922,8 @@ class LightingSignupPage(QWidget):
             handler=payment_fields.get("handler", ""),
             payment_method=payment_fields.get("payment_method", "cash"),
             transfer_last5=payment_fields.get("transfer_last5", ""),
+            receipt_method=payment_fields.get("receipt_method", "ELECTRONIC"),
+            paper_receipt_number=payment_fields.get("paper_receipt_number", ""),
         )
         paid_count = int(result.get("paid_count") or 0)
         skipped_count = int(result.get("skipped_count") or 0)

--- a/tests/test_activity_payment_mapping.py
+++ b/tests/test_activity_payment_mapping.py
@@ -176,6 +176,41 @@ def test_mark_activity_paid_maps_category_and_note(controller_with_payment_db):
     assert "雙虎祝壽×2" in row["note"]
 
 
+def test_mark_activity_paid_records_paper_receipt(controller_with_payment_db):
+    c = controller_with_payment_db
+    result = c.mark_activity_signups_paid(
+        "A1",
+        ["S1"],
+        handler="櫃台A",
+        receipt_method="PAPER",
+        paper_receipt_number="PAPER-001",
+    )
+    assert result["paid_count"] == 1
+
+    cur = c.conn.cursor()
+    tx = cur.execute(
+        """
+        SELECT receipt_method, paper_receipt_number, note
+        FROM transactions
+        ORDER BY id DESC
+        LIMIT 1
+        """
+    ).fetchone()
+    signup = cur.execute(
+        """
+        SELECT receipt_method, paper_receipt_number
+        FROM activity_signups
+        WHERE id = 'S1'
+        """
+    ).fetchone()
+
+    assert tx["receipt_method"] == "PAPER"
+    assert tx["paper_receipt_number"] == "PAPER-001"
+    assert "紙本收據號：PAPER-001" in tx["note"]
+    assert signup["receipt_method"] == "PAPER"
+    assert signup["paper_receipt_number"] == "PAPER-001"
+
+
 def test_create_activity_signup_log_contains_person_name(controller_with_payment_db, monkeypatch):
     c = controller_with_payment_db
     logs = []

--- a/tests/test_activity_payment_mapping.py
+++ b/tests/test_activity_payment_mapping.py
@@ -211,6 +211,32 @@ def test_mark_activity_paid_records_paper_receipt(controller_with_payment_db):
     assert signup["paper_receipt_number"] == "PAPER-001"
 
 
+def test_mark_activity_paid_allows_empty_paper_receipt_number(controller_with_payment_db):
+    c = controller_with_payment_db
+    result = c.mark_activity_signups_paid(
+        "A1",
+        ["S1"],
+        handler="櫃台A",
+        receipt_method="PAPER",
+        paper_receipt_number="",
+    )
+    assert result["paid_count"] == 1
+
+    cur = c.conn.cursor()
+    tx = cur.execute(
+        "SELECT receipt_method, paper_receipt_number, note FROM transactions ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    signup = cur.execute(
+        "SELECT receipt_method, paper_receipt_number FROM activity_signups WHERE id = 'S1'"
+    ).fetchone()
+
+    assert tx["receipt_method"] == "PAPER"
+    assert tx["paper_receipt_number"] == ""
+    assert "紙本收據號：" not in tx["note"]
+    assert signup["receipt_method"] == "PAPER"
+    assert signup["paper_receipt_number"] == ""
+
+
 def test_create_activity_signup_log_contains_person_name(controller_with_payment_db, monkeypatch):
     c = controller_with_payment_db
     logs = []

--- a/tests/test_activity_signup_page.py
+++ b/tests/test_activity_signup_page.py
@@ -19,7 +19,13 @@ class _FakePaymentDialog:
         return QDialog.Accepted
 
     def get_payload(self):
-        return {"handler": "王小明(admin)", "payment_method": "cash", "transfer_last5": ""}
+        return {
+            "handler": "王小明(admin)",
+            "payment_method": "cash",
+            "transfer_last5": "",
+            "receipt_method": "ELECTRONIC",
+            "paper_receipt_number": "",
+        }
 
 
 class FakePersonPanel(QWidget):

--- a/tests/test_finance_report_controller.py
+++ b/tests/test_finance_report_controller.py
@@ -148,6 +148,8 @@ def test_get_transactions_supports_paper_receipt_filter(tmp_path):
     db = tmp_path / "finance_paper.db"
     conn = sqlite3.connect(db)
     _seed_transactions(conn)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE people (id TEXT PRIMARY KEY, name TEXT, phone_mobile TEXT, phone_home TEXT, address TEXT)")
     conn.close()
 
     controller = AppController(db_path=str(db))

--- a/tests/test_finance_report_controller.py
+++ b/tests/test_finance_report_controller.py
@@ -142,3 +142,22 @@ def test_get_transactions_supports_phone_keyword_and_voided_filter(tmp_path):
     assert any(str(r.get("receipt_number") or "") == "R100" for r in by_phone)
     only_voided = controller.get_transactions("income", voided_filter="only")
     assert all(int((r.get("is_voided") or 0)) == 1 for r in only_voided)
+
+
+def test_get_transactions_supports_paper_receipt_filter(tmp_path):
+    db = tmp_path / "finance_paper.db"
+    conn = sqlite3.connect(db)
+    _seed_transactions(conn)
+    conn.close()
+
+    controller = AppController(db_path=str(db))
+    cur = controller.conn.cursor()
+    cur.execute(
+        "UPDATE transactions SET receipt_method = 'PAPER', paper_receipt_number = 'P001' WHERE receipt_number = 'R2'"
+    )
+    controller.conn.commit()
+
+    rows = controller.get_transactions("income", receipt_filter="paper")
+
+    assert [r["receipt_number"] for r in rows] == ["R2"]
+    assert rows[0]["paper_receipt_number"] == "P001"

--- a/tests/test_lighting_logging.py
+++ b/tests/test_lighting_logging.py
@@ -229,6 +229,35 @@ def test_mark_lighting_paid_records_paper_receipt(controller_with_lighting_log_d
     assert signup["paper_receipt_number"] == "LP-001"
 
 
+def test_mark_lighting_paid_allows_empty_paper_receipt_number(controller_with_lighting_log_db):
+    c = controller_with_lighting_log_db
+    sid = c.upsert_lighting_signup(2026, "P1", ["L01"], note="紙本收據待補")
+
+    result = c.mark_lighting_signups_paid(
+        2026,
+        [sid],
+        handler="櫃台A",
+        receipt_method="PAPER",
+        paper_receipt_number="",
+    )
+
+    assert result["paid_count"] == 1
+    cur = c.conn.cursor()
+    tx = cur.execute(
+        "SELECT receipt_method, paper_receipt_number, note FROM transactions WHERE source_id = ? ORDER BY id DESC LIMIT 1",
+        (sid,),
+    ).fetchone()
+    signup = cur.execute(
+        "SELECT receipt_method, paper_receipt_number FROM lighting_signups WHERE id = ?",
+        (sid,),
+    ).fetchone()
+    assert tx["receipt_method"] == "PAPER"
+    assert tx["paper_receipt_number"] == ""
+    assert "紙本收據號：" not in tx["note"]
+    assert signup["receipt_method"] == "PAPER"
+    assert signup["paper_receipt_number"] == ""
+
+
 def test_mark_lighting_paid_empty_handler_writes_system_log(controller_with_lighting_log_db, monkeypatch):
     system_calls = []
 

--- a/tests/test_lighting_logging.py
+++ b/tests/test_lighting_logging.py
@@ -190,6 +190,45 @@ def test_mark_lighting_paid_stores_transfer_payment_fields(controller_with_light
     assert row["transfer_last5"] == "TX123"
 
 
+def test_mark_lighting_paid_records_paper_receipt(controller_with_lighting_log_db):
+    c = controller_with_lighting_log_db
+    sid = c.upsert_lighting_signup(2026, "P1", ["L01"], note="紙本收據測試")
+
+    result = c.mark_lighting_signups_paid(
+        2026,
+        [sid],
+        handler="櫃台A",
+        receipt_method="PAPER",
+        paper_receipt_number="LP-001",
+    )
+
+    assert result["paid_count"] == 1
+    cur = c.conn.cursor()
+    tx = cur.execute(
+        """
+        SELECT receipt_method, paper_receipt_number, note
+        FROM transactions
+        WHERE source_id = ?
+        ORDER BY id DESC
+        LIMIT 1
+        """,
+        (sid,),
+    ).fetchone()
+    signup = cur.execute(
+        """
+        SELECT receipt_method, paper_receipt_number
+        FROM lighting_signups
+        WHERE id = ?
+        """,
+        (sid,),
+    ).fetchone()
+    assert tx["receipt_method"] == "PAPER"
+    assert tx["paper_receipt_number"] == "LP-001"
+    assert "紙本收據號：LP-001" in tx["note"]
+    assert signup["receipt_method"] == "PAPER"
+    assert signup["paper_receipt_number"] == "LP-001"
+
+
 def test_mark_lighting_paid_empty_handler_writes_system_log(controller_with_lighting_log_db, monkeypatch):
     system_calls = []
 

--- a/tests/test_lighting_signup_page.py
+++ b/tests/test_lighting_signup_page.py
@@ -20,6 +20,8 @@ class _FakePaymentDialog:
             "handler": "王小明(admin)",
             "payment_method": "transfer",
             "transfer_last5": "T1234",
+            "receipt_method": "ELECTRONIC",
+            "paper_receipt_number": "",
         }
 
 
@@ -44,13 +46,24 @@ class _FakeLightingController:
     def get_lighting_signup_item_totals(self, signup_year, keyword=""):
         return []
 
-    def mark_lighting_signups_paid(self, signup_year, signup_ids, handler="", payment_method="cash", transfer_last5=""):
+    def mark_lighting_signups_paid(
+        self,
+        signup_year,
+        signup_ids,
+        handler="",
+        payment_method="cash",
+        transfer_last5="",
+        receipt_method="ELECTRONIC",
+        paper_receipt_number="",
+    ):
         self.last_payment_call = {
             "signup_year": signup_year,
             "signup_ids": signup_ids,
             "handler": handler,
             "payment_method": payment_method,
             "transfer_last5": transfer_last5,
+            "receipt_method": receipt_method,
+            "paper_receipt_number": paper_receipt_number,
         }
         return {"paid_count": 1, "skipped_count": 0}
 
@@ -108,6 +121,8 @@ def test_lighting_payment_uses_dialog_and_fixed_handler(qtbot, monkeypatch):
         "handler": "王小明(admin)",
         "payment_method": "transfer",
         "transfer_last5": "T1234",
+        "receipt_method": "ELECTRONIC",
+        "paper_receipt_number": "",
     }
     assert messages[-1] == ("繳費完成", "姓名 王小明 繳費完成。")
 

--- a/tests/test_payment_method_dialog.py
+++ b/tests/test_payment_method_dialog.py
@@ -64,17 +64,21 @@ def test_payment_dialog_accepts_transfer_payload(qtbot):
     }
 
 
-def test_payment_dialog_requires_paper_receipt_number(qtbot):
+def test_payment_dialog_accepts_empty_paper_receipt_number(qtbot):
     dlg = PaymentMethodDialog(handler="王小明(admin)", can_edit_handler=False)
     qtbot.addWidget(dlg)
     dlg.receipt_method_combo.setCurrentIndex(dlg.receipt_method_combo.findData("PAPER"))
 
-    with patch("app.dialogs.payment_method_dialog.QMessageBox.information") as mock_info:
-        dlg._accept_if_valid()
+    dlg._accept_if_valid()
 
-    mock_info.assert_called_once()
-    assert dlg.result() == 0
-    assert dlg.get_payload() == {}
+    assert dlg.result() == QDialog.Accepted
+    assert dlg.get_payload() == {
+        "handler": "王小明(admin)",
+        "payment_method": "cash",
+        "transfer_last5": "",
+        "receipt_method": "PAPER",
+        "paper_receipt_number": "",
+    }
 
 
 def test_payment_dialog_accepts_paper_receipt_payload(qtbot):

--- a/tests/test_payment_method_dialog.py
+++ b/tests/test_payment_method_dialog.py
@@ -28,6 +28,8 @@ def test_payment_dialog_accepts_cash_payload(qtbot):
         "handler": "王小明(admin)",
         "payment_method": "cash",
         "transfer_last5": "",
+        "receipt_method": "ELECTRONIC",
+        "paper_receipt_number": "",
     }
 
 
@@ -57,4 +59,37 @@ def test_payment_dialog_accepts_transfer_payload(qtbot):
         "handler": "王小明(admin)",
         "payment_method": "transfer",
         "transfer_last5": "A1234",
+        "receipt_method": "ELECTRONIC",
+        "paper_receipt_number": "",
+    }
+
+
+def test_payment_dialog_requires_paper_receipt_number(qtbot):
+    dlg = PaymentMethodDialog(handler="王小明(admin)", can_edit_handler=False)
+    qtbot.addWidget(dlg)
+    dlg.receipt_method_combo.setCurrentIndex(dlg.receipt_method_combo.findData("PAPER"))
+
+    with patch("app.dialogs.payment_method_dialog.QMessageBox.information") as mock_info:
+        dlg._accept_if_valid()
+
+    mock_info.assert_called_once()
+    assert dlg.result() == 0
+    assert dlg.get_payload() == {}
+
+
+def test_payment_dialog_accepts_paper_receipt_payload(qtbot):
+    dlg = PaymentMethodDialog(handler="王小明(admin)", can_edit_handler=False)
+    qtbot.addWidget(dlg)
+    dlg.receipt_method_combo.setCurrentIndex(dlg.receipt_method_combo.findData("PAPER"))
+    dlg.paper_receipt_number_input.setText("P123456")
+
+    dlg._accept_if_valid()
+
+    assert dlg.result() == QDialog.Accepted
+    assert dlg.get_payload() == {
+        "handler": "王小明(admin)",
+        "payment_method": "cash",
+        "transfer_last5": "",
+        "receipt_method": "PAPER",
+        "paper_receipt_number": "P123456",
     }


### PR DESCRIPTION
## 變更摘要

調整活動報名與安燈報名的繳費流程，支援「電子收據」與「紙本收據」兩種收據型態。紙本收據繳費時仍會建立收支交易、保留系統收據號，並可記錄或事後補上紙本收據號。

## 主要改動

- 活動/安燈繳費新增收據型態選擇：電子收據、紙本收據
- 紙本收據交易新增欄位記錄：
  - `receipt_method`
  - `paper_receipt_number`
- 紙本收據號可在繳費時輸入，也可先留空後續補登
- 收支頁新增「只看紙本」篩選
- 收支頁新增「補紙本收據號」功能
- 收支頁清除按鈕改為「清除篩選」，並會一併清除搜尋、只看作廢、只看紙本
- 收據列印時，紙本收據號獨立顯示在系統收據號上方，不再塞在摘要中造成文字過長

## 權限與限制

- 補紙本收據號僅限可編輯收入資料的角色操作
- 作廢單據不可補改紙本收據號
- 非紙本收據交易不可補紙本收據號
- 原本現金/轉帳付款方式邏輯未變更